### PR TITLE
Fix token decimal crash

### DIFF
--- a/src/utils/get-fastest-provider.ts
+++ b/src/utils/get-fastest-provider.ts
@@ -10,6 +10,9 @@ function getHandler(networkId: number | string) {
     networkName: null,
     runtimeRpcs: null,
     networkRpcs: null,
+    proxySettings: {
+      retryCount: 5,
+    },
   };
 
   return new RPCHandler(config as HandlerConstructorConfig);
@@ -18,8 +21,7 @@ function getHandler(networkId: number | string) {
 export async function getFastestProvider(networkId: number | string): Promise<providers.JsonRpcProvider> {
   try {
     const handler = getHandler(networkId);
-    const provider = await handler.getFastestRpcProvider();
-    return new providers.JsonRpcProvider(provider.connection.url);
+    return await handler.getFastestRpcProvider();
   } catch (e) {
     throw new Error(`Failed to get fastest provider for networkId: ${networkId}`);
   }


### PR DESCRIPTION
Resolves https://github.com/ubiquity-os-marketplace/text-conversation-rewards/issues/148

The problem was that instead of using the provider returned by the `rpc-handler` which has a Proxy that retries with different RPCs, we initialized a standard JsonRpcProvider with url from the returned provider.
I've also increased retry count to 5 to make it more reliable.