### PR TITLE
fix: fix permit signer

### DIFF
--- a/src/handlers/generate-erc20-permit.ts
+++ b/src/handlers/generate-erc20-permit.ts
@@ -90,15 +90,8 @@ export async function generateErc20PermitSignature(
 
   const { domain, types, values } = SignatureTransfer.getPermitData(permitTransferFromData, PERMIT2_ADDRESS, evmNetworkId);
 
-  const domainData = {
-    name: domain.name,
-    version: domain.version || "1", //  default to 1 if it's undefined
-    chainId: domain.chainId,
-    verifyingContract: domain.verifyingContract,
-  };
-
   try {
-    const signature = await adminWallet._signTypedData(domainData, types, values);
+    const signature = await adminWallet._signTypedData(domain, types, values);
 
     const erc20Permit: PermitReward = {
       tokenType: TokenType.ERC20,

--- a/tests/generate-erc20-permit.test.ts
+++ b/tests/generate-erc20-permit.test.ts
@@ -68,10 +68,21 @@ describe("generateErc20PermitSignature", () => {
 
     const result = await generateErc20PermitSignature(context, SPENDER, amount, ERC20_REWARD_TOKEN_ADDRESS);
 
-    expect(result).toBeDefined();
-    expect(result).not.toContain("Permit not generated");
-    expect(result).toBeInstanceOf(Object);
+    const expectedResult = {
+      tokenType: 'ERC20',
+      tokenAddress: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
+      beneficiary: '0xefC0e701A824943b469a694aC564Aa1efF7Ab7dd',
+      nonce: '28290789875493039658039458533958603742651083423638415458747066904844975862062',
+      deadline: '115792089237316195423570985008687907853269984665640564039457584007913129639935',
+      amount: '100000000000000000000',
+      owner: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+      signature: '0xad87653fb0ecf740c73b78a8f414cdd5b1ffb18670cde5a1d21c65e43d6bb2a36c5470c5529334dc11566f0c380889b734a8539d69ec74cc2abf37af0ea7a7781b',
+      networkId: 100
+    };
+
+    expect(result).toEqual(expectedResult);
     expect(context.logger.info).toHaveBeenCalledWith("Generated ERC20 permit2 signature", expect.any(Object));
+    
   });
 
   it("should throw error when evmPrivateEncrypted is not defined", async () => {


### PR DESCRIPTION
Resolves https://github.com/ubiquity/pay.ubq.fi/issues/323

TLDR; [This](https://github.com/ubiquity-os/permit-generation/pull/70) PR broke permit signature in [this](https://github.com/ubiquity-os/permit-generation/pull/70/files#diff-a85780b2806b3d56cfa46cb3ae9e404ee06a3c1221d0508ef4c8bee91048a784R95) line.

**Root cause**

Check [this](https://github.com/ubiquity/audit.ubq.fi/issues/15#issuecomment-2421534945) buggy permit where permit owner is `0x9051eDa96dB419c967189F4Ac303a290F3327680` but recovered signer from signature is `0x51afbf762cdedc2683afecc2ccdd93da6a071ff8` while the expected behavior for both of those values to be equal. The root cause is that [here](https://github.com/ubiquity-os/permit-generation/pull/70/files#diff-a85780b2806b3d56cfa46cb3ae9e404ee06a3c1221d0508ef4c8bee91048a784R95) `domain.version` was added to the signed data while original permit2's EIP712 contract [verifies](https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/EIP712.sol#L34) only: `domain.name`, `domain.chainId` and `domain.verifyingContract`. Thus adding a new field to signed data made a signature created by the `ubiquity-os/permit-generation` package not matching the one actually [verified](https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/src/SignatureTransfer.sol#L65).

This PR:
- removes `domain.version` from signed data (and keeps only `domain.name`, `domain.chainId` and `domain.verifyingContract` originally produced by [SignatureTransfer.getPermitData()](https://github.com/rndquu/permit-generation/blob/e4e8eaef1d065cffdcb379b001c62d0fa971010e/src/handlers/generate-erc20-permit.ts#L91))
- adds a unit test so that possible issues with permit signatures are spotted easily

The PR that broke permit signatures was introduced in `ubiquity-os/permit-generation v2.0.0` and `ubiquity-os-marketplace/text-conversation-rewards` started using that version in `v1.5.1` on 12 October. So all permits generated since the 12 October are not claimable by contributors (and probably should be regenerated on demand once a new version of `ubiquity-os/permit-generation` is released).

P.S. The error could not be catched locally at `pay.ubq.fi` because `pay.ubq.fi` test helper script [generates](https://github.com/ubiquity/pay.ubq.fi/blob/625a74be0adbb282cc46901ac2df945fcfc3fa6e/scripts/typescript/generate-erc20-permit-url.ts#L42) a permit signature without the help of the `ubiquity-os/permit-generation` plugin.
