### PR TITLE
fix: changed endpoint for the RPC proxy

### DIFF
--- a/src/utils/get-fastest-provider.ts
+++ b/src/utils/get-fastest-provider.ts
@@ -2,7 +2,7 @@ import { ethers, providers } from "ethers";
 
 export async function getRpcProvider(networkId: number | string): Promise<providers.JsonRpcProvider> {
   try {
-    const provider = new ethers.providers.JsonRpcProvider(`https://rpc.ubq.fi/${networkId}`);
+    const provider = new ethers.providers.JsonRpcProvider(`https://permit2-rpc-proxy.deno.dev/${networkId}`);
     // We make one call to make sure our provider is responding
     await provider.getBlockNumber();
     return provider;


### PR DESCRIPTION
Changed the endpoint to resolve our current `NO NETWORK` issues.

How did I test?
https://github.com/ubiquity/permit2-rpc-manager/issues/6#issuecomment-3084590012
<!--
- You must link the issue number e.g. "Resolves #1234"
- Please do not replace the keyword "Resolves" https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
