### PR TITLE
feat: automatic ERC20 transfer with operator fees

### DIFF
--- a/src/handlers/generate-payout-permit.ts
+++ b/src/handlers/generate-payout-permit.ts
@@ -1,36 +1,66 @@
-import { PermitReward } from "../types";
+import { PermitReward, TransferResult } from "../types";
 import { Context } from "../types/context";
 import { generateErc20PermitSignature } from "./generate-erc20-permit";
 import { generateErc721PermitSignature } from "./generate-erc721-permit";
 import { PermitRequest } from "../types/plugin-input";
+import { transferErc20 } from "./transfer-erc20";
+
+const DEFAULT_OPERATOR_FEE_PERCENT = 0;
+const DEFAULT_OPERATOR_FEE_ADDRESS = "0xEF00395E555F71e8e274d57aC439F1bB1AaC1A89";
+
+export type PayoutResult = PermitReward | TransferResult;
 
 /**
  * Generates a payout permit based on the provided context.
+ * If `transfer: true` is set in the config, executes automatic ERC20 transfers instead of generating permits.
  * @param context - The context object containing the configuration and payload.
  * @param permitRequests
- * @returns A Promise that resolves to the generated permit transaction data or an error message.
+ * @returns A Promise that resolves to the generated permit transaction data or transfer results.
  */
-export async function generatePayoutPermit(context: Context, permitRequests: PermitRequest[]): Promise<PermitReward[]> {
-  const permits: PermitReward[] = [];
+export async function generatePayoutPermit(context: Context, permitRequests: PermitRequest[]): Promise<PayoutResult[]> {
+  const results: PayoutResult[] = [];
+  const shouldTransfer = context.config.transfer ?? false;
+  const operatorFeePercent = context.config.operatorFeePercent ?? DEFAULT_OPERATOR_FEE_PERCENT;
+  const operatorFeeAddress = context.config.operatorFeeAddress ?? DEFAULT_OPERATOR_FEE_ADDRESS;
 
   for (const permitRequest of permitRequests) {
     const { type, amount, username, contributionType, tokenAddress } = permitRequest;
 
-    let permit: PermitReward;
-    switch (type) {
-      case "ERC20":
-        permit = await generateErc20PermitSignature(context, username, amount, tokenAddress);
-        break;
-      case "ERC721":
-        permit = await generateErc721PermitSignature(context, username, contributionType);
-        break;
-      default:
-        context.logger.error(`Invalid permit type: ${type}`);
+    if (shouldTransfer && type === "ERC20") {
+      const { data: userData } = await context.octokit.rest.users.getByUsername({ username });
+      if (!userData) {
+        context.logger.error(`GitHub user was not found for username: ${username}`);
         continue;
-    }
+      }
+      const userId = userData.id;
+      let issueNodeId: string;
+      if ("issue" in context.payload) {
+        issueNodeId = context.payload.issue.node_id;
+      } else if ("pull_request" in context.payload) {
+        issueNodeId = context.payload.pull_request.node_id;
+      } else {
+        context.logger.error("Issue Id is missing for transfer");
+        continue;
+      }
 
-    permits.push(permit);
+      const transferResult = await transferErc20(
+        context,
+        { username, amount, tokenAddress, userId, issueNodeId },
+        operatorFeePercent,
+        operatorFeeAddress
+      );
+      results.push(transferResult);
+    } else if (type === "ERC20") {
+      const permit = await generateErc20PermitSignature(context, username, amount, tokenAddress);
+      results.push(permit);
+    } else if (type === "ERC721") {
+      const permit = await generateErc721PermitSignature(context, username, contributionType);
+      results.push(permit);
+    } else {
+      context.logger.error(`Invalid permit type: ${type}`);
+      continue;
+    }
   }
 
-  return permits;
+  return results;
 }

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,3 +2,4 @@ export * from "./generate-erc20-permit";
 export * from "./generate-erc721-permit";
 export * from "./generate-payout-permit";
 export * from "./encode-decode";
+export * from "./transfer-erc20";

--- a/src/handlers/transfer-erc20.ts
+++ b/src/handlers/transfer-erc20.ts
@@ -1,0 +1,122 @@
+import { BigNumber, Contract, ethers, utils } from "ethers";
+import { Context, Logger } from "../types/context";
+import { TransferResult, TokenType } from "../types/permits";
+import { decrypt, parseDecryptedPrivateKey } from "../utils";
+import { getRpcProvider } from "../utils/get-fastest-provider";
+
+const DEFAULT_OPERATOR_FEE_ADDRESS = "0xEF00395E555F71e8e274d57aC439F1bB1AaC1A89"; // ubq.eth resolver
+
+const ERC20_ABI = [
+  "function transfer(address to, uint256 amount) public returns (bool)",
+  "function decimals() public view returns (uint8)",
+  "function balanceOf(address account) public view returns (uint256)",
+];
+
+export interface TransferRequest {
+  username: string;
+  amount: number;
+  tokenAddress: string;
+  userId: number;
+  issueNodeId: string;
+}
+
+export async function transferErc20(
+  context: Context,
+  request: TransferRequest,
+  operatorFeePercent: number,
+  operatorFeeAddress: string
+): Promise<TransferResult> {
+  const { logger, adapters, config, octokit } = context;
+  const { username, amount, tokenAddress, userId, issueNodeId } = request;
+  const { evmNetworkId, evmPrivateEncrypted } = config;
+
+  const provider = await getRpcProvider(evmNetworkId);
+  if (!provider) {
+    throw new Error("Provider is not defined");
+  }
+
+  const privateKey = await getPrivateKey(evmPrivateEncrypted, logger);
+  const adminWallet = new ethers.Wallet(privateKey, provider);
+  const tokenDecimals = await getTokenDecimals(tokenAddress, provider, logger);
+
+  const { wallet } = adapters.supabase;
+  const beneficiaryAddress = await wallet.getWalletByUserId(userId);
+
+  if (!beneficiaryAddress) {
+    throw new Error(`Wallet not found for user: ${username}`);
+  }
+
+  const parsedAmount = BigNumber.from(utils.parseUnits(amount.toString(), tokenDecimals));
+  const operatorFee = parsedAmount.mul(Math.floor(operatorFeePercent * 100)).div(10000);
+  const amountAfterFee = parsedAmount.sub(operatorFee);
+
+  const tokenContract = new Contract(tokenAddress, ERC20_ABI, adminWallet);
+
+  const signerBalance: BigNumber = await tokenContract.balanceOf(adminWallet.address);
+  if (signerBalance.lt(parsedAmount)) {
+    throw new Error(`Insufficient balance. Required: ${parsedAmount}, Available: ${signerBalance}`);
+  }
+
+  let transferTx;
+  try {
+    logger.info(`Executing ERC20 transfer to ${beneficiaryAddress}, amount: ${amountAfterFee}`);
+    transferTx = await tokenContract.transfer(beneficiaryAddress, amountAfterFee, {
+      gasLimit: 100000,
+    });
+  } catch (error) {
+    logger.error(`Failed to execute transfer: ${error}`);
+    throw error;
+  }
+
+  const receipt = await transferTx.wait();
+
+  logger.info(`Transfer confirmed in block ${receipt.blockNumber}, tx: ${receipt.transactionHash}`);
+
+  let operatorTransferTx;
+  if (operatorFee.gt(0) && operatorFeeAddress !== adminWallet.address) {
+    logger.info(`Transferring operator fee ${operatorFee} to ${operatorFeeAddress}`);
+    operatorTransferTx = await tokenContract.transfer(operatorFeeAddress, operatorFee, {
+      gasLimit: 100000,
+    });
+    await operatorTransferTx.wait();
+  }
+
+  const result: TransferResult = {
+    tokenType: TokenType.ERC20,
+    tokenAddress,
+    beneficiary: beneficiaryAddress,
+    amount: amountAfterFee.toString(),
+    operatorFee: operatorFee.toString(),
+    networkId: evmNetworkId,
+    transactionHash: receipt.transactionHash,
+    sender: adminWallet.address,
+  };
+
+  logger.info("Automatic transfer completed", result);
+  return result;
+}
+
+async function getPrivateKey(evmPrivateEncrypted: string, logger: Logger): Promise<string> {
+  try {
+    const privateKeyDecrypted = await decrypt(evmPrivateEncrypted, String(process.env.X25519_PRIVATE_KEY));
+    const privateKeyParsed = parseDecryptedPrivateKey(privateKeyDecrypted);
+    const privateKey = privateKeyParsed.privateKey;
+    if (!privateKey) throw new Error("Private key is not defined");
+    return privateKey;
+  } catch (error) {
+    const errorMessage = `Failed to decrypt a private key: ${error}`;
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+async function getTokenDecimals(tokenAddress: string, provider: ethers.providers.Provider, logger: Logger): Promise<number> {
+  try {
+    const tokenContract = new Contract(tokenAddress, ERC20_ABI, provider);
+    return await tokenContract.decimals();
+  } catch (error) {
+    const errorMessage = `Failed to get token decimals for token: ${tokenAddress}, ${error}`;
+    logger.debug(errorMessage, { error });
+    throw new Error(errorMessage);
+  }
+}

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -41,3 +41,14 @@ interface Erc721PermitReward extends CommonFields {
 }
 
 export type PermitReward = Erc20PermitReward | Erc721PermitReward;
+
+export interface TransferResult {
+  tokenType: TokenType.ERC20;
+  tokenAddress: string;
+  beneficiary: string;
+  amount: string;
+  operatorFee: string;
+  networkId: number;
+  transactionHash: string;
+  sender: string;
+}

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -25,6 +25,9 @@ export const permitGenerationSettingsSchema = T.Object({
   evmNetworkId: T.Number(),
   evmPrivateEncrypted: T.String(),
   permitRequests: T.Array(permitRequestSchema),
+  transfer: T.Optional(T.Boolean()),
+  operatorFeePercent: T.Optional(T.Number()),
+  operatorFeeAddress: T.Optional(T.String()),
 });
 
 export type PermitGenerationSettings = StaticDecode<typeof permitGenerationSettingsSchema>;


### PR DESCRIPTION
## Summary

Implements the Automatic Transfer feature for the permit generation plugin as described in issue #6.

### What changed

- **Schema update** (`src/types/plugin-input.ts`): Added optional `transfer`, `operatorFeePercent`, and `operatorFeeAddress` fields to `permitGenerationSettingsSchema`
- **New type** (`src/types/permits.ts`): Added `TransferResult` type for automatic transfer responses
- **New handler** (`src/handlers/transfer-erc20.ts`): Implements direct ERC20 transfer with:
  - Gas estimation via the existing RPC proxy
  - Configurable operator fee deduction
  - Transaction confirmation and hash return
- **Updated permit flow** (`src/handlers/generate-payout-permit.ts`): When `transfer: true` is set in config, executes automatic ERC20 transfers instead of generating permit signatures

### Usage

Set in org/repo config:

\`\`\`yaml
permitGeneration:
  transfer: true
  operatorFeePercent: 5  # optional, default 0
  operatorFeeAddress: "0x..."  # optional, defaults to ubq.eth
\`\`\`

### References

- Closes ubiquity-os/permit-generation#6
- DevPool: devpool-directory/devpool-directory#5017