### PR TITLE
fix: resolve CodeRabbit review comments for auto-transfer (Closes #6)

### DIFF
--- a/src/generate-permits-from-context.ts
+++ b/src/generate-permits-from-context.ts
@@ -1,10 +1,10 @@
-import * as github from "@actions/github";
+﻿import * as github from "@actions/github";
 import { Octokit } from "@octokit/rest";
 import { Value } from "@sinclair/typebox/value";
 import { createClient } from "@supabase/supabase-js";
 import { createAdapters } from "./adapters";
 import { Database } from "./adapters/supabase/types/database";
-import { generatePayoutPermit } from "./handlers";
+import { generatePayoutPermit, executeAutoTransfers } from "./handlers";
 import { registerWallet } from "./handlers/register-wallet";
 import { Context } from "./types/context";
 import { envSchema } from "./types/env";
@@ -62,8 +62,16 @@ export async function generatePermitsFromContext() {
     await handleSlashCommands(context, octokit);
   } else {
     const permits = await generatePayoutPermit(context, settings.permitRequests);
-    await returnDataToKernel(env.GITHUB_TOKEN, inputs.stateId, permits);
-    return JSON.stringify(permits);
+
+    // Execute auto-transfers if enabled in config
+    let transferResults = null;
+    if (settings.transfer) {
+      transferResults = await executeAutoTransfers(context, permits);
+    }
+
+    const output = { permits, transferResults };
+    await returnDataToKernel(env.GITHUB_TOKEN, inputs.stateId, output);
+    return JSON.stringify(output);
   }
 
   return null;

--- a/src/handlers/auto-transfer.ts
+++ b/src/handlers/auto-transfer.ts
@@ -1,0 +1,313 @@
+import { ethers } from "ethers";
+import { PermitReward, TokenType } from "../types";
+import { Context } from "../types/context";
+import { decrypt, parseDecryptedPrivateKey } from "../utils";
+import { getRpcProvider } from "../utils/get-fastest-provider";
+
+// Minimal ERC20 ABI for transfer and decimals
+const ERC20_ABI = [
+  "function transfer(address to, uint256 amount) returns (bool)",
+  "function decimals() view returns (uint8)",
+  "function balanceOf(address owner) view returns (uint256)",
+];
+
+// Default gas limit estimate for ERC20 transfer
+const ERC20_TRANSFER_GAS_LIMIT = 65000;
+
+// Transaction confirmation timeout in milliseconds
+const TX_CONFIRM_TIMEOUT_MS = 120000;
+
+export interface TransferResult {
+  beneficiary: string;
+  tokenAddress: string;
+  amount: string;
+  txHash: string | null;
+  networkId: number;
+  operatorFee: string;
+  gasEstimate: GasEstimate;
+  status: "success" | "skipped" | "failed";
+  error?: string;
+}
+
+export interface GasEstimate {
+  gasLimit: number;
+  gasPrice: string; // in wei
+  estimatedCost: string; // in native token (wei)
+  networkId: number;
+}
+
+/**
+ * Estimates gas fees for an ERC20 transfer on the given network.
+ * Dynamically fetches current gas price from the provider.
+ */
+export async function estimateGas(
+  provider: ethers.providers.JsonRpcProvider,
+  fromAddress: string,
+  toAddress: string,
+  tokenAddress: string,
+  amount: string
+): Promise<GasEstimate> {
+  const network = await provider.getNetwork();
+
+  // Get current fee data (supports EIP-1559 and legacy)
+  const feeData = await provider.getFeeData();
+  const gasPrice = feeData.gasPrice || feeData.maxFeePerGas || ethers.BigNumber.from("20000000000"); // 20 gwei fallback
+
+  const erc20 = new ethers.Contract(tokenAddress, ERC20_ABI, provider);
+
+  // Try to estimate gas for the actual transfer
+  let gasLimit: number;
+  try {
+    const estimated = await erc20.estimateGas.transfer(toAddress, amount, { from: fromAddress });
+    // Add 20% buffer
+    gasLimit = Math.ceil(estimated.toNumber() * 1.2);
+  } catch {
+    // Fallback to default estimate
+    gasLimit = ERC20_TRANSFER_GAS_LIMIT;
+  }
+
+  const estimatedCost = ethers.BigNumber.from(gasLimit).mul(gasPrice);
+
+  return {
+    gasLimit,
+    gasPrice: gasPrice.toString(),
+    estimatedCost: estimatedCost.toString(),
+    networkId: network.chainId,
+  };
+}
+
+/**
+ * Waits for transaction confirmation with a timeout.
+ */
+async function waitForConfirmation(tx: ethers.ContractTransaction, timeoutMs: number): Promise<ethers.providers.TransactionReceipt> {
+  return Promise.race([
+    tx.wait(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("Transaction confirmation timeout")), timeoutMs)
+    ),
+  ]);
+}
+
+/**
+ * Formats a token amount for logging, handling tokens that don't expose decimals().
+ */
+async function formatTokenAmount(amount: ethers.BigNumber, erc20: ethers.Contract): Promise<string> {
+  try {
+    const decimals = await erc20.decimals();
+    return ethers.utils.formatUnits(amount, decimals);
+  } catch {
+    return amount.toString();
+  }
+}
+
+/**
+ * Executes automatic transfers for generated permits.
+ * Only processes ERC20 permits with `transfer: true` in config.
+ */
+export async function executeAutoTransfers(context: Context, permits: PermitReward[]): Promise<TransferResult[]> {
+  const { config } = context;
+  const results: TransferResult[] = [];
+
+  // Skip if transfer is not enabled
+  if (!config.transfer) {
+    context.logger.info("Auto-transfer is not enabled, skipping.");
+    return results;
+  }
+
+  const operatorFeePercent = config.operatorFeePercent ?? 0;
+  if (operatorFeePercent < 0 || operatorFeePercent > 100) {
+    throw new Error(`Invalid operatorFeePercent: ${operatorFeePercent}. Must be between 0 and 100.`);
+  }
+
+  // Get admin wallet — wrap setup in try/catch to return failed results instead of throwing
+  let provider: ethers.providers.JsonRpcProvider;
+  try {
+    provider = await getRpcProvider(config.evmNetworkId);
+    if (!provider) {
+      return permits.map(permit => ({
+        beneficiary: permit.beneficiary,
+        tokenAddress: permit.tokenAddress,
+        amount: permit.amount.toString(),
+        txHash: null,
+        networkId: permit.networkId,
+        operatorFee: "0",
+        gasEstimate: { gasLimit: 0, gasPrice: "0", estimatedCost: "0", networkId: permit.networkId },
+        status: "failed" as const,
+        error: "Failed to get RPC provider for auto-transfer",
+      }));
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return permits.map(permit => ({
+      beneficiary: permit.beneficiary,
+      tokenAddress: permit.tokenAddress,
+      amount: permit.amount.toString(),
+      txHash: null,
+      networkId: permit.networkId,
+      operatorFee: "0",
+      gasEstimate: { gasLimit: 0, gasPrice: "0", estimatedCost: "0", networkId: permit.networkId },
+      status: "failed" as const,
+      error: `Provider setup failed: ${msg}`,
+    }));
+  }
+
+  let adminWallet: ethers.Wallet;
+  try {
+    const privateKeyDecrypted = await decrypt(config.evmPrivateEncrypted, String(process.env.X25519_PRIVATE_KEY));
+    const privateKeyParsed = parseDecryptedPrivateKey(privateKeyDecrypted);
+    const privateKey = privateKeyParsed.privateKey;
+    if (!privateKey) {
+      return permits.map(permit => ({
+        beneficiary: permit.beneficiary,
+        tokenAddress: permit.tokenAddress,
+        amount: permit.amount.toString(),
+        txHash: null,
+        networkId: permit.networkId,
+        operatorFee: "0",
+        gasEstimate: { gasLimit: 0, gasPrice: "0", estimatedCost: "0", networkId: permit.networkId },
+        status: "failed" as const,
+        error: "Private key is not defined for auto-transfer",
+      }));
+    }
+    adminWallet = new ethers.Wallet(privateKey, provider);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return permits.map(permit => ({
+      beneficiary: permit.beneficiary,
+      tokenAddress: permit.tokenAddress,
+      amount: permit.amount.toString(),
+      txHash: null,
+      networkId: permit.networkId,
+      operatorFee: "0",
+      gasEstimate: { gasLimit: 0, gasPrice: "0", estimatedCost: "0", networkId: permit.networkId },
+      status: "failed" as const,
+      error: `Key setup failed: ${msg}`,
+    }));
+  }
+
+  for (const permit of permits) {
+    // Network consistency guard — each permit carries its own networkId,
+    // but execution network comes from config. Reject mismatch early to
+    // avoid signing on the wrong chain.
+    if (permit.networkId !== config.evmNetworkId) {
+      results.push({
+        beneficiary: permit.beneficiary,
+        tokenAddress: permit.tokenAddress,
+        amount: permit.amount?.toString() ?? "0",
+        txHash: null,
+        networkId: permit.networkId,
+        operatorFee: "0",
+        gasEstimate: { gasLimit: 0, gasPrice: "0", estimatedCost: "0", networkId: permit.networkId },
+        status: "skipped",
+        error: `Network mismatch: permit is on ${permit.networkId}, config expects ${config.evmNetworkId}`,
+      });
+      continue;
+    }
+
+    // Only auto-transfer ERC20 tokens
+    if (permit.tokenType !== TokenType.ERC20) {
+      results.push({
+        beneficiary: permit.beneficiary,
+        tokenAddress: permit.tokenAddress,
+        amount: permit.amount?.toString() ?? "0",
+        txHash: null,
+        networkId: permit.networkId,
+        operatorFee: "0",
+        gasEstimate: {
+          gasLimit: 0,
+          gasPrice: "0",
+          estimatedCost: "0",
+          networkId: permit.networkId,
+        },
+        status: "skipped",
+        error: "Non-ERC20 permit, auto-transfer skipped",
+      });
+      continue;
+    }
+
+    try {
+      const erc20 = new ethers.Contract(permit.tokenAddress, ERC20_ABI, adminWallet);
+
+      // Calculate amounts — use optional chaining because ERC721 permits
+      // may omit the amount field entirely.
+      const rawAmount = permit.amount ?? 0;
+      const totalAmount = ethers.BigNumber.from(rawAmount);
+      const operatorFee = totalAmount.mul(Math.round(operatorFeePercent * 100)).div(10000);
+      const beneficiaryAmount = totalAmount.sub(operatorFee);
+
+      // Handle zero-amount beneficiary transfer (fee is 100%) — some ERC20
+      // tokens revert on zero-value transfers, so we skip to avoid wasting gas.
+      if (beneficiaryAmount.isZero()) {
+        results.push({
+          beneficiary: permit.beneficiary,
+          tokenAddress: permit.tokenAddress,
+          amount: "0",
+          txHash: null,
+          networkId: permit.networkId,
+          operatorFee: operatorFee.toString(),
+          gasEstimate: { gasLimit: 0, gasPrice: "0", estimatedCost: "0", networkId: permit.networkId },
+          status: "skipped",
+          error: "Beneficiary amount is zero after operator fee",
+        });
+        continue;
+      }
+
+      // Estimate gas
+      const gasEstimate = await estimateGas(provider, adminWallet.address, permit.beneficiary, permit.tokenAddress, beneficiaryAmount.toString());
+
+      // Format amounts for logging — use raw units if decimals() is unavailable
+      const [beneficiaryDisplayAmount, operatorFeeDisplayAmount] = await Promise.all([
+        formatTokenAmount(beneficiaryAmount, erc20),
+        formatTokenAmount(operatorFee, erc20),
+      ]);
+
+      context.logger.info(
+        `Auto-transfer: ${beneficiaryDisplayAmount} tokens to ${permit.beneficiary}, ` +
+          `operator fee: ${operatorFeeDisplayAmount}, ` +
+          `estimated gas: ${ethers.utils.formatEther(gasEstimate.estimatedCost)} native token`
+      );
+
+      // Transfer to beneficiary
+      const transferTx = await erc20.transfer(permit.beneficiary, beneficiaryAmount, {
+        gasLimit: gasEstimate.gasLimit,
+      });
+
+      context.logger.info(`Transfer tx submitted: ${transferTx.hash}`);
+
+      // Wait for confirmation with timeout
+      await waitForConfirmation(transferTx, TX_CONFIRM_TIMEOUT_MS);
+
+      results.push({
+        beneficiary: permit.beneficiary,
+        tokenAddress: permit.tokenAddress,
+        amount: beneficiaryAmount.toString(),
+        txHash: transferTx.hash,
+        networkId: permit.networkId,
+        operatorFee: operatorFee.toString(),
+        gasEstimate,
+        status: "success",
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      context.logger.error(`Auto-transfer failed for ${permit.beneficiary}: ${errorMessage}`);
+      results.push({
+        beneficiary: permit.beneficiary,
+        tokenAddress: permit.tokenAddress,
+        amount: permit.amount?.toString() ?? "0",
+        txHash: null,
+        networkId: permit.networkId,
+        operatorFee: "0",
+        gasEstimate: {
+          gasLimit: 0,
+          gasPrice: "0",
+          estimatedCost: "0",
+          networkId: permit.networkId,
+        },
+        status: "failed",
+        error: errorMessage,
+      });
+    }
+  }
+
+  return results;
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,4 +1,5 @@
-export * from "./generate-erc20-permit";
+﻿export * from "./generate-erc20-permit";
 export * from "./generate-erc721-permit";
 export * from "./generate-payout-permit";
 export * from "./encode-decode";
+export * from "./auto-transfer";

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -1,4 +1,4 @@
-import { EmitterWebhookEvent as WebhookEvent, EmitterWebhookEventName as WebhookEventName } from "@octokit/webhooks";
+﻿import { EmitterWebhookEvent as WebhookEvent, EmitterWebhookEventName as WebhookEventName } from "@octokit/webhooks";
 import { SupportedEvents } from "./context";
 import { StaticDecode, Type as T } from "@sinclair/typebox";
 
@@ -25,6 +25,14 @@ export const permitGenerationSettingsSchema = T.Object({
   evmNetworkId: T.Number(),
   evmPrivateEncrypted: T.String(),
   permitRequests: T.Array(permitRequestSchema),
+  /**
+   * If true, automatically transfer funds to the beneficiary after generating the permit.
+   */
+  transfer: T.Optional(T.Boolean()),
+  /**
+   * Optional operator fee percentage (0-100) deducted from each transfer.
+   */
+  operatorFeePercent: T.Optional(T.Number({ minimum: 0, maximum: 100 })),
 });
 
 export type PermitGenerationSettings = StaticDecode<typeof permitGenerationSettingsSchema>;


### PR DESCRIPTION
Closes #6

## Summary
Resolves CodeRabbit review comments from PRs #123 and #125 for the Automatic Transfer feature (Issue #6,  bounty).

## Changes
- **Handle missing decimals() gracefully**: Tokens that don't implement decimals() now log raw units instead of failing the entire transfer path
- **Add transaction confirmation timeout**: 120s timeout on tx.wait() to avoid indefinite blocking on congested networks
- **Extract helper functions** (formatTokenAmount, waitForConfirmation) to reduce cognitive complexity

## CodeRabbit comments addressed
- [x] Avoid hard-failing when token decimals() is unavailable (PR #125 comment)
- [x] Add confirmation timeout to transferTx.wait() (PR #125 comment)
- [x] Reduce cognitive complexity by extracting helpers (PR #125 comment)