### PR TITLE
feat: add optional automatic ERC20 transfer mode

### DIFF
--- a/SUBMISSION_NOTE.md
+++ b/SUBMISSION_NOTE.md
@@ -1,0 +1,24 @@
+Resolves #6
+
+## Summary
+
+- Adds an optional `transfer: true` setting that routes ERC20 payout requests through a direct token transfer path instead of permit signature generation.
+- Adds `generateErc20Transfer`, which resolves the beneficiary wallet from the request username, decrypts the configured admin wallet, reads token decimals, estimates transfer gas, applies a 20% gas buffer, and sends the ERC20 transfer.
+- Adds operator fee support through worker-level environment settings: `UBIQUITY_FEE_BPS` and `UBIQUITY_FEE_RECIPIENT`.
+- Keeps existing ERC20 permit and ERC721 permit behavior unchanged when `transfer` is not enabled.
+
+## Safety And Edge Cases
+
+- The handler fails closed if token decimals cannot be read instead of assuming 18 decimals.
+- Fee basis points must be between 0 and 10000.
+- A fee recipient is required when a non-zero fee is configured, avoiding hidden ENS assumptions on non-ENS networks.
+- The beneficiary transfer is sent before the optional fee transfer, so a fee cannot be collected if the beneficiary payout fails.
+
+## Verification
+
+- `bun x jest tests/generate-payout-permit.test.ts --runInBand`
+- `bun x jest --runInBand`
+- `bun run build`
+- `bun x prettier --check src/types/plugin-input.ts src/types/env.ts src/types/permits.ts src/handlers/generate-payout-permit.ts src/handlers/index.ts src/handlers/generate-erc20-transfer.ts tests/generate-payout-permit.test.ts`
+- `bun x eslint src/types/plugin-input.ts src/types/env.ts src/types/permits.ts src/handlers/generate-payout-permit.ts src/handlers/index.ts src/handlers/generate-erc20-transfer.ts tests/generate-payout-permit.test.ts`
+- `bun x cspell src/types/plugin-input.ts src/types/env.ts src/types/permits.ts src/handlers/generate-payout-permit.ts src/handlers/index.ts src/handlers/generate-erc20-transfer.ts tests/generate-payout-permit.test.ts`

--- a/src/handlers/generate-erc20-transfer.ts
+++ b/src/handlers/generate-erc20-transfer.ts
@@ -1,0 +1,209 @@
+import { BigNumber, Contract, ethers, utils } from "ethers";
+import { Erc20TransferReward, TokenType } from "../types";
+import { Context, Logger } from "../types/context";
+import { decrypt, parseDecryptedPrivateKey } from "../utils";
+import { getRpcProvider } from "../utils/get-fastest-provider";
+
+const ERC20_TRANSFER_ABI = ["function decimals() public view returns (uint8)", "function transfer(address to, uint256 amount) public returns (bool)"];
+const BASIS_POINTS = 10000;
+const DEFAULT_GAS_BUFFER_BPS = 2000;
+
+interface TransferPayload {
+  evmNetworkId: number;
+  evmPrivateEncrypted: string;
+  walletAddress: string;
+  logger: Logger;
+  userId: number;
+  feeRecipient?: string;
+  feeBps?: string;
+}
+
+export function splitTransferAmount(amount: BigNumber | string, feeBps: number) {
+  if (feeBps < 0 || feeBps > BASIS_POINTS) {
+    throw new Error("Operator fee bps must be between 0 and 10000");
+  }
+
+  const grossAmount = BigNumber.from(amount);
+  const operatorFeeAmount = grossAmount.mul(feeBps).div(BASIS_POINTS);
+  const beneficiaryAmount = grossAmount.sub(operatorFeeAmount);
+
+  return {
+    beneficiaryAmount: beneficiaryAmount.toString(),
+    operatorFeeAmount: operatorFeeAmount.toString(),
+  };
+}
+
+export function addGasBuffer(gasEstimate: BigNumber | string, bufferBps = DEFAULT_GAS_BUFFER_BPS) {
+  if (bufferBps < 0) {
+    throw new Error("Gas buffer bps must not be negative");
+  }
+
+  const gas = BigNumber.from(gasEstimate);
+  return gas.add(gas.mul(bufferBps).div(BASIS_POINTS));
+}
+
+export async function generateErc20Transfer(payload: TransferPayload, username: string, amount: number, tokenAddress: string): Promise<Erc20TransferReward>;
+export async function generateErc20Transfer(context: Context, username: string, amount: number, tokenAddress: string): Promise<Erc20TransferReward>;
+export async function generateErc20Transfer(
+  contextOrPayload: Context | TransferPayload,
+  username: string,
+  amount: number,
+  tokenAddress: string
+): Promise<Erc20TransferReward> {
+  let logger: Logger;
+  let walletAddress: string | null | undefined;
+  let evmNetworkId: number;
+  let evmPrivateEncrypted: string;
+  let feeRecipient: string | undefined;
+  let feeBps: string | undefined;
+
+  if ("walletAddress" in contextOrPayload) {
+    logger = contextOrPayload.logger;
+    walletAddress = contextOrPayload.walletAddress;
+    evmNetworkId = contextOrPayload.evmNetworkId;
+    evmPrivateEncrypted = contextOrPayload.evmPrivateEncrypted;
+    feeRecipient = contextOrPayload.feeRecipient;
+    feeBps = contextOrPayload.feeBps;
+  } else {
+    logger = contextOrPayload.logger;
+    evmNetworkId = contextOrPayload.config.evmNetworkId;
+    evmPrivateEncrypted = contextOrPayload.config.evmPrivateEncrypted;
+    feeRecipient = contextOrPayload.env.UBIQUITY_FEE_RECIPIENT;
+    feeBps = contextOrPayload.env.UBIQUITY_FEE_BPS;
+
+    const { data: userData } = await contextOrPayload.octokit.rest.users.getByUsername({ username });
+    if (!userData) {
+      throw new Error(`GitHub user was not found for id ${username}`);
+    }
+
+    walletAddress = await contextOrPayload.adapters.supabase.wallet.getWalletByUserId(userData.id);
+  }
+
+  if (!username) {
+    throw new Error("User was not found");
+  }
+  if (!walletAddress) {
+    const errorMessage = "ERC20 transfer error: Wallet not found";
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+
+  const provider = await getRpcProvider(evmNetworkId);
+  if (!provider) {
+    logger.error("Provider is not defined");
+    throw new Error("Provider is not defined");
+  }
+
+  const privateKey = await getPrivateKey(evmPrivateEncrypted, logger);
+  const adminWallet = await getAdminWallet(privateKey, provider, logger);
+  const tokenContract = new Contract(tokenAddress, ERC20_TRANSFER_ABI, adminWallet);
+  const tokenDecimals = await getTokenDecimals(tokenContract, tokenAddress, logger);
+  const grossAmount = utils.parseUnits(amount.toString(), tokenDecimals);
+  const feeBasisPoints = parseFeeBps(feeBps);
+  const { beneficiaryAmount, operatorFeeAmount } = splitTransferAmount(grossAmount, feeBasisPoints);
+
+  const beneficiaryTransfer = await sendTokenTransfer(tokenContract, walletAddress, beneficiaryAmount);
+  const feeTransfers = [];
+
+  if (!BigNumber.from(operatorFeeAmount).isZero()) {
+    if (!feeRecipient) {
+      throw new Error("UBIQUITY_FEE_RECIPIENT must be configured when UBIQUITY_FEE_BPS is greater than zero");
+    }
+    const resolvedFeeRecipient = await resolveTransferAddress(provider, feeRecipient);
+    const feeTransfer = await sendTokenTransfer(tokenContract, resolvedFeeRecipient, operatorFeeAmount);
+    feeTransfers.push({
+      beneficiary: resolvedFeeRecipient,
+      amount: operatorFeeAmount,
+      transactionHash: feeTransfer.transactionHash,
+      gasEstimate: feeTransfer.gasEstimate,
+    });
+  }
+
+  const transferReward: Erc20TransferReward = {
+    type: "erc20-transfer",
+    tokenType: TokenType.ERC20,
+    tokenAddress,
+    beneficiary: walletAddress,
+    amount: beneficiaryAmount,
+    owner: adminWallet.address,
+    networkId: evmNetworkId,
+    transactionHash: beneficiaryTransfer.transactionHash,
+    gasEstimate: beneficiaryTransfer.gasEstimate,
+    feeTransfers,
+  };
+
+  logger.info("Transferred ERC20 reward", transferReward);
+
+  return transferReward;
+}
+
+function parseFeeBps(feeBps?: string) {
+  if (!feeBps) {
+    return 0;
+  }
+
+  const parsed = Number.parseInt(feeBps, 10);
+  if (!Number.isFinite(parsed) || parsed < 0 || parsed > BASIS_POINTS) {
+    throw new Error("UBIQUITY_FEE_BPS must be an integer between 0 and 10000");
+  }
+
+  return parsed;
+}
+
+async function getPrivateKey(evmPrivateEncrypted: string, logger: Logger) {
+  try {
+    const privateKeyDecrypted = await decrypt(evmPrivateEncrypted, String(process.env.X25519_PRIVATE_KEY));
+    const privateKeyParsed = parseDecryptedPrivateKey(privateKeyDecrypted);
+    const privateKey = privateKeyParsed.privateKey;
+    if (!privateKey) throw new Error("Private key is not defined");
+    return privateKey;
+  } catch (error) {
+    const errorMessage = `Failed to decrypt a private key: ${error}`;
+    logger.error(errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+async function getAdminWallet(privateKey: string, provider: ethers.providers.Provider, logger: Logger) {
+  try {
+    return new ethers.Wallet(privateKey, provider);
+  } catch (error) {
+    const errorMessage = `Failed to instantiate wallet: ${error}`;
+    logger.debug(errorMessage);
+    throw new Error(errorMessage);
+  }
+}
+
+async function getTokenDecimals(tokenContract: Contract, tokenAddress: string, logger: Logger) {
+  try {
+    return await tokenContract.decimals();
+  } catch (error) {
+    const errorMessage = `Failed to get token decimals for token: ${tokenAddress}, ${error}`;
+    logger.debug(errorMessage, { error });
+    throw new Error(errorMessage);
+  }
+}
+
+async function sendTokenTransfer(tokenContract: Contract, beneficiary: string, amount: string) {
+  const gasEstimate = await tokenContract.estimateGas.transfer(beneficiary, amount);
+  const gasLimit = addGasBuffer(gasEstimate);
+  const transaction = await tokenContract.transfer(beneficiary, amount, { gasLimit });
+
+  return {
+    transactionHash: transaction.hash,
+    gasEstimate: gasEstimate.toString(),
+  };
+}
+
+async function resolveTransferAddress(provider: ethers.providers.Provider, beneficiary: string) {
+  if (utils.isAddress(beneficiary)) {
+    return beneficiary;
+  }
+
+  const resolvedAddress = await provider.resolveName(beneficiary);
+  if (!resolvedAddress) {
+    throw new Error(`Unable to resolve transfer beneficiary: ${beneficiary}`);
+  }
+
+  return resolvedAddress;
+}

--- a/src/handlers/generate-payout-permit.ts
+++ b/src/handlers/generate-payout-permit.ts
@@ -1,6 +1,7 @@
-import { PermitReward } from "../types";
+import { PayoutReward } from "../types";
 import { Context } from "../types/context";
 import { generateErc20PermitSignature } from "./generate-erc20-permit";
+import { generateErc20Transfer } from "./generate-erc20-transfer";
 import { generateErc721PermitSignature } from "./generate-erc721-permit";
 import { PermitRequest } from "../types/plugin-input";
 
@@ -10,16 +11,18 @@ import { PermitRequest } from "../types/plugin-input";
  * @param permitRequests
  * @returns A Promise that resolves to the generated permit transaction data or an error message.
  */
-export async function generatePayoutPermit(context: Context, permitRequests: PermitRequest[]): Promise<PermitReward[]> {
-  const permits: PermitReward[] = [];
+export async function generatePayoutPermit(context: Context, permitRequests: PermitRequest[]): Promise<PayoutReward[]> {
+  const permits: PayoutReward[] = [];
 
   for (const permitRequest of permitRequests) {
     const { type, amount, username, contributionType, tokenAddress } = permitRequest;
 
-    let permit: PermitReward;
+    let permit: PayoutReward;
     switch (type) {
       case "ERC20":
-        permit = await generateErc20PermitSignature(context, username, amount, tokenAddress);
+        permit = context.config.transfer
+          ? await generateErc20Transfer(context, username, amount, tokenAddress)
+          : await generateErc20PermitSignature(context, username, amount, tokenAddress);
         break;
       case "ERC721":
         permit = await generateErc721PermitSignature(context, username, contributionType);

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,4 +1,5 @@
 export * from "./generate-erc20-permit";
+export * from "./generate-erc20-transfer";
 export * from "./generate-erc721-permit";
 export * from "./generate-payout-permit";
 export * from "./encode-decode";

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -8,6 +8,8 @@ export const envSchema = T.Object({
   SUPABASE_KEY: T.String(),
   NFT_MINTER_PRIVATE_KEY: T.Optional(T.String()),
   NFT_CONTRACT_ADDRESS: T.Optional(T.String()),
+  UBIQUITY_FEE_RECIPIENT: T.Optional(T.String()),
+  UBIQUITY_FEE_BPS: T.Optional(T.String()),
 });
 
 export type Env = StaticDecode<typeof envSchema>;

--- a/src/types/permits.ts
+++ b/src/types/permits.ts
@@ -41,3 +41,26 @@ interface Erc721PermitReward extends CommonFields {
 }
 
 export type PermitReward = Erc20PermitReward | Erc721PermitReward;
+
+interface Erc20TransferFee {
+  beneficiary: string;
+  amount: BigNumberish;
+  transactionHash: string;
+  gasEstimate: BigNumberish;
+}
+
+export interface Erc20TransferReward {
+  type: "erc20-transfer";
+  tokenType: TokenType.ERC20;
+  tokenAddress: string;
+  beneficiary: string;
+  amount: BigNumberish;
+  owner: string;
+  networkId: number;
+  transactionHash: string;
+  gasEstimate: BigNumberish;
+  feeTransfers: Erc20TransferFee[];
+}
+
+export type TransferReward = Erc20TransferReward;
+export type PayoutReward = PermitReward | TransferReward;

--- a/src/types/plugin-input.ts
+++ b/src/types/plugin-input.ts
@@ -25,6 +25,7 @@ export const permitGenerationSettingsSchema = T.Object({
   evmNetworkId: T.Number(),
   evmPrivateEncrypted: T.String(),
   permitRequests: T.Array(permitRequestSchema),
+  transfer: T.Optional(T.Boolean()),
 });
 
 export type PermitGenerationSettings = StaticDecode<typeof permitGenerationSettingsSchema>;

--- a/tests/generate-payout-permit.test.ts
+++ b/tests/generate-payout-permit.test.ts
@@ -1,11 +1,20 @@
 // import { generateErc20PermitSignature } from "../src/handlers/generate-erc20-permit";
 import { generateErc20PermitSignature, generatePayoutPermit } from "../src";
+import { addGasBuffer, generateErc20Transfer, splitTransferAmount } from "../src/handlers/generate-erc20-transfer";
 // import { generateErc721PermitSignature } from "../src/handlers/generate-erc721-permit";
 import { Context } from "../src/types/context";
 import { cypherText, mockContext, SPENDER } from "./constants";
 import { describe, expect, it, beforeEach, afterEach, jest } from "@jest/globals";
 
 jest.mock("../src/handlers/generate-erc20-permit");
+jest.mock("../src/handlers/generate-erc20-transfer", () => {
+  const actual = jest.requireActual<typeof import("../src/handlers/generate-erc20-transfer")>("../src/handlers/generate-erc20-transfer");
+
+  return {
+    ...actual,
+    generateErc20Transfer: jest.fn(),
+  };
+});
 jest.mock("../src/handlers/generate-erc721-permit");
 
 describe("generatePayoutPermit", () => {
@@ -46,6 +55,16 @@ describe("generatePayoutPermit", () => {
         networkId: 1,
       },
     });
+    (generateErc20Transfer as jest.Mock).mockReturnValue({
+      type: "erc20-transfer",
+      tokenAddress: "TOKEN_ADDRESS",
+      beneficiary: SPENDER,
+      amount: "100",
+      networkId: 1,
+      transactionHash: "0xabc",
+      gasEstimate: "21000",
+      feeTransfers: [],
+    });
   });
 
   afterEach(() => {
@@ -74,5 +93,45 @@ describe("generatePayoutPermit", () => {
       { erc20: { amount: 100, networkId: 1, spender: SPENDER, token: "TOKEN_ADDRESS" } },
       { erc20: { amount: 100, networkId: 1, spender: SPENDER, token: "TOKEN_ADDRESS" } },
     ]);
+  });
+
+  it("should use direct ERC20 transfer when transfer setting is enabled", async () => {
+    context.config.transfer = true;
+
+    const result = await generatePayoutPermit(context, [
+      {
+        type: "ERC20",
+        amount: 100,
+        username: "123",
+        contributionType: "ISSUE",
+        tokenAddress: "TOKEN_ADDRESS",
+      },
+    ]);
+
+    expect(generateErc20Transfer).toHaveBeenCalledWith(context, "123", 100, "TOKEN_ADDRESS");
+    expect(generateErc20PermitSignature).not.toHaveBeenCalled();
+    expect(result).toMatchObject([
+      {
+        type: "erc20-transfer",
+        tokenAddress: "TOKEN_ADDRESS",
+        beneficiary: SPENDER,
+        amount: "100",
+        networkId: 1,
+        transactionHash: "0xabc",
+        gasEstimate: "21000",
+        feeTransfers: [],
+      },
+    ]);
+  });
+
+  it("should split operator fee from direct transfer amount", () => {
+    expect(splitTransferAmount("1000", 250)).toEqual({
+      beneficiaryAmount: "975",
+      operatorFeeAmount: "25",
+    });
+  });
+
+  it("should add a configurable gas buffer to direct transfer estimates", () => {
+    expect(addGasBuffer("21000", 2000).toString()).toBe("25200");
   });
 });


### PR DESCRIPTION
Resolves #6

## Summary

- Adds an optional `transfer: true` setting that routes ERC20 payout requests through a direct token transfer path instead of permit signature generation.
- Adds `generateErc20Transfer`, which resolves the beneficiary wallet from the request username, decrypts the configured admin wallet, reads token decimals, estimates transfer gas, applies a 20% gas buffer, and sends the ERC20 transfer.
- Adds operator fee support through worker-level environment settings: `UBIQUITY_FEE_BPS` and `UBIQUITY_FEE_RECIPIENT`.
- Keeps existing ERC20 permit and ERC721 permit behavior unchanged when `transfer` is not enabled.

## Safety And Edge Cases

- The handler fails closed if token decimals cannot be read instead of assuming 18 decimals.
- Fee basis points must be between 0 and 10000.
- A fee recipient is required when a non-zero fee is configured, avoiding hidden ENS assumptions on non-ENS networks.
- The beneficiary transfer is sent before the optional fee transfer, so a fee cannot be collected if the beneficiary payout fails.

## Verification

- `bun x jest tests/generate-payout-permit.test.ts --runInBand`
- `bun x jest --runInBand`
- `bun run build`
- `bun x prettier --check src/types/plugin-input.ts src/types/env.ts src/types/permits.ts src/handlers/generate-payout-permit.ts src/handlers/index.ts src/handlers/generate-erc20-transfer.ts tests/generate-payout-permit.test.ts`
- `bun x eslint src/types/plugin-input.ts src/types/env.ts src/types/permits.ts src/handlers/generate-payout-permit.ts src/handlers/index.ts src/handlers/generate-erc20-transfer.ts tests/generate-payout-permit.test.ts`
- `bun x cspell src/types/plugin-input.ts src/types/env.ts src/types/permits.ts src/handlers/generate-payout-permit.ts src/handlers/index.ts src/handlers/generate-erc20-transfer.ts tests/generate-payout-permit.test.ts`
